### PR TITLE
8 user friendly effects access via optical train getitem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ dist
 *scopesim_pkg_dir_tmp/
 *misc/
 *TEST.fits
+*temp*

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -11,7 +11,7 @@ __all__ = ["DetectorList"]
 
 class DetectorList(Effect):
     def __init__(self, **kwargs):
-        super(Effect, self).__init__(**kwargs)
+        super(DetectorList, self).__init__(**kwargs)
         self.meta["z_order"] = [90, 290, 390, 490]
         self.meta["pixel_scale"] = "!INST.pixel_scale"      # arcsec
         self.meta.update(kwargs)

--- a/scopesim/effects/effects.py
+++ b/scopesim/effects/effects.py
@@ -37,6 +37,7 @@ class Effect(DataContainer):
         super(Effect, self).__init__(**kwargs)
         self.meta["z_order"] = []
         self.meta["include"] = True
+        self.meta.update(kwargs)
 
     def apply_to(self, obj):
         if not isinstance(obj, (SourceBase, FieldOfViewBase,

--- a/scopesim/effects/effects_utils.py
+++ b/scopesim/effects/effects_utils.py
@@ -35,7 +35,8 @@ def get_all_effects(effects, effect_class):
         for eff_cls in effect_class:
             my_effects += get_all_effects(effects, eff_cls)
     else:
-        my_effects = [eff for eff in effects if isinstance(eff, effect_class)]
+        my_effects = [eff for eff in effects
+                      if isinstance(eff, effect_class) and eff.meta["include"]]
 
     return my_effects
 

--- a/scopesim/effects/electronic.py
+++ b/scopesim/effects/electronic.py
@@ -10,7 +10,7 @@ from ..utils import real_colname, from_currsys, check_keys
 
 class SummedExposure(Effect):
     def __init__(self, **kwargs):
-        super(Effect, self).__init__(**kwargs)
+        super(SummedExposure, self).__init__(**kwargs)
         self.meta["z_order"] = [860]
 
         required_keys = ["dit", "ndit"]
@@ -60,7 +60,7 @@ class BasicReadoutNoise(Effect):
 
 class ShotNoise(Effect):
     def __init__(self, **kwargs):
-        super(Effect, self).__init__(**kwargs)
+        super(ShotNoise, self).__init__(**kwargs)
         self.meta["z_order"] = [820]
         self.meta["random_seed"] = "!SIM.random.seed"
         self.meta.update(kwargs)
@@ -77,7 +77,7 @@ class ShotNoise(Effect):
             # basically the same. For large arrays the normal distribution
             # takes only 60% as long as the poisson distribution
             data = det._hdu.data
-            below = data < 2**10
+            below = data < 2**20
             above = np.invert(below)
             data[below] = np.random.poisson(data[below]).astype(float)
             data[above] = np.random.normal(data[above], np.sqrt(data[above]))
@@ -94,7 +94,7 @@ class DarkCurrent(Effect):
 
     """
     def __init__(self, **kwargs):
-        super(Effect, self).__init__(**kwargs)
+        super(DarkCurrent, self).__init__(**kwargs)
         self.meta["z_order"] = [830]
 
         required_keys = ["value", "dit", "ndit"]

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -66,8 +66,6 @@ class OpticalElement:
                 self.properties["element_name"] = yaml_dict["name"]
             if "effects" in yaml_dict and len(yaml_dict["effects"]) > 0:
                 for eff_dic in yaml_dict["effects"]:
-                    if "include" in eff_dic and eff_dic["include"] is False:
-                        continue
                     if "name" in eff_dic and hasattr(rc.__currsys__,
                                                      "ignore_effects"):
                         if eff_dic["name"] in rc.__currsys__.ignore_effects:
@@ -96,6 +94,9 @@ class OpticalElement:
 
         effects = []
         for eff in self.effects:
+            if not eff.meta["include"]:
+                continue
+
             if "z_order" in eff.meta:
                 z = eff.meta["z_order"]
                 if isinstance(z, (list, tuple)):
@@ -123,13 +124,16 @@ class OpticalElement:
         self.add_effect(other)
 
     def __getitem__(self, item):
+        obj = None
         if isinstance(item, efs.Effect):
-            return self.get_all(item)
+            obj = self.get_all(item)
         elif isinstance(item, int):
-            return self.effects[item]
+            obj = self.effects[item]
         elif isinstance(item, str):
-            return [eff for eff in self.effects
-                    if eff.meta["name"] == item][0]
+            obj = [eff for eff in self.effects
+                   if eff.meta["name"] == item]
+
+        return obj
 
     def __repr__(self):
         msg = '\nOpticalElement : "{}" contains {} Effects: \n' \

--- a/scopesim/optics/optical_element.py
+++ b/scopesim/optics/optical_element.py
@@ -1,4 +1,5 @@
 import warnings
+from inspect import isclass
 
 from .. import effects as efs
 from ..effects.effects_utils import make_effect, get_all_effects
@@ -69,7 +70,7 @@ class OpticalElement:
                     if "name" in eff_dic and hasattr(rc.__currsys__,
                                                      "ignore_effects"):
                         if eff_dic["name"] in rc.__currsys__.ignore_effects:
-                            continue
+                            eff_dic["include"] = False
 
                     self.effects += [make_effect(eff_dic, **self.properties)]
 
@@ -125,7 +126,7 @@ class OpticalElement:
 
     def __getitem__(self, item):
         obj = None
-        if isinstance(item, efs.Effect):
+        if isclass(item):
             obj = self.get_all(item)
         elif isinstance(item, int):
             obj = self.effects[item]

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -158,3 +158,11 @@ class OpticalTrain:
         if len(dy) > 0 and "packages" in dy:
             self.cmds.update(packages=self.default_yamls[0]["packages"])
         rc.__currsys__ = self.cmds
+
+    def __getitem__(self, item):
+        # search optical elements, then effects
+        return self.optics_manager[item]
+
+    def __setitem__(self, key, value):
+        # ..todo:: search optical elements, then effects
+        self.optics_manager[key] = value

--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -14,7 +14,52 @@ class OpticalTrain:
 
     Parameters
     ----------
-    cmds : UserCommands
+    cmds : UserCommands, str
+        If the name of an instrument is passed, OpticalTrain tries to find the
+        instrument package, and internally creates the UserCommands object
+
+    Examples
+    --------
+    Create an optical train::
+
+        >>> import scopesim as im
+        >>> cmd = sim.UserCommands("MICADO")
+        >>> opt = sim.OpticalTrain(cmd)
+
+    Observe a Source object::
+
+        >>> src = sim.source.source_templates.empty_sky()
+        >>> opt.observe(src)
+        >>> hdus = opt.readout()
+
+    List the effects modelled in an OpticalTrain::
+
+        >>> print(opt.effects)
+
+    Effects can be accessed by using the name of the effect::
+
+        >>> print(opt["dark_current"])
+
+    To include or exclude an effect during a simulation run, use the
+    ``.include`` attribute of the effect::
+
+         >>> opt["dark_current"].include = False
+
+    Data used by an Effect object is contained in the ``.data`` attribute, while
+    other information is contained in the ``.meta`` attribute::
+
+        >>> opt["dark_current"].data
+        >>> opt["dark_current"].meta
+
+    Meta data values can be set by either using the ``.meta`` attribute
+    directly::
+
+        >>> opt["dark_current"].meta["value"] = 0.5
+
+    or by passing a dictionary (with one or multiple entries) to the
+    OpticalTrain object::
+
+        >>> opt["dark_current"] = {"value": 0.75, "dit": 30}
 
     """
 
@@ -39,6 +84,9 @@ class OpticalTrain:
         user_commands : UserCommands
 
         """
+
+        if isinstance(user_commands, str):
+            cmds = UserCommands(use_instrument=user_commands)
 
         if not isinstance(user_commands, UserCommands):
             raise ValueError("user_commands must be a UserCommands object: "
@@ -159,10 +207,13 @@ class OpticalTrain:
             self.cmds.update(packages=self.default_yamls[0]["packages"])
         rc.__currsys__ = self.cmds
 
+    @property
+    def effects(self):
+        return self.optics_manager.list_effects()
+
     def __getitem__(self, item):
-        # search optical elements, then effects
         return self.optics_manager[item]
 
     def __setitem__(self, key, value):
-        # ..todo:: search optical elements, then effects
         self.optics_manager[key] = value
+

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -208,16 +208,29 @@ class OpticsManager:
         self.add_effect(other)
 
     def __getitem__(self, item):
+        obj = None
         if isinstance(item, efs.Effect):
             effects = []
             for opt_el in self.optical_elements:
                 effects += opt_el.get_all(item)
-            return effects
+            obj = effects
         elif isinstance(item, int):
-            return self.optical_elements[item]
+            obj = self.optical_elements[item]
         elif isinstance(item, str):
-            return [opt_el for opt_el in self.optical_elements
-                    if opt_el.meta["name"] == item][0]
+            obj = [opt_el for opt_el in self.optical_elements
+                   if opt_el.meta["name"] == item]
+            obj += [opt_el[item] for opt_el in self.optical_elements]
+
+        return obj
+
+    def __setitem__(self, key, value):
+        obj = self.__getitem__(key)
+        if isinstance(obj, efs.Effect) and isinstance(value, dict):
+            if len(obj) == 1:
+                obj.meta.update(value)
+            else:
+                warnings.warn("{} does not return a singular object:\n {}"
+                              "".format(key, obj))
 
     def __repr__(self):
         msg = "\nOpticsManager contains {} OpticalElements \n" \

--- a/scopesim/rc.py
+++ b/scopesim/rc.py
@@ -12,9 +12,9 @@ with open(os.path.join(__pkg_dir__, "defaults.yaml")) as f:
 user_rc_path = os.path.expanduser("~/.scopesim_rc.yaml")
 if os.path.exists(user_rc_path):
     with open(user_rc_path) as f:
-        user_dicts = [dic for dic in yaml.load_all(f)]
+        dicts += [dic for dic in yaml.load_all(f)]
 
-__config__ = SystemDict(dicts + user_dicts)
+__config__ = SystemDict(dicts)
 __currsys__ = __config__
 
 __search_path__ = ['./',

--- a/scopesim/rc.py
+++ b/scopesim/rc.py
@@ -2,7 +2,6 @@ import os
 import yaml
 
 from .system_dict import SystemDict
-from .commands.user_commands import UserCommands
 
 __pkg_dir__ = os.path.dirname(__file__)
 
@@ -17,6 +16,6 @@ if os.path.exists(user_rc_path):
 __config__ = SystemDict(dicts)
 __currsys__ = __config__
 
-__search_path__ = ['./',
-                   __config__["!SIM.file.local_packages_path"],
-                   __pkg_dir__]
+__search_path__ = [__config__["!SIM.file.local_packages_path"],
+                   __pkg_dir__] + __config__["!SIM.file.search_path"]
+

--- a/scopesim/rc.py
+++ b/scopesim/rc.py
@@ -8,7 +8,13 @@ __pkg_dir__ = os.path.dirname(__file__)
 
 with open(os.path.join(__pkg_dir__, "defaults.yaml")) as f:
     dicts = [dic for dic in yaml.load_all(f)]
-__config__ = SystemDict(dicts)
+
+user_rc_path = os.path.expanduser("~/.scopesim_rc.yaml")
+if os.path.exists(user_rc_path):
+    with open(user_rc_path) as f:
+        user_dicts = [dic for dic in yaml.load_all(f)]
+
+__config__ = SystemDict(dicts + user_dicts)
 __currsys__ = __config__
 
 __search_path__ = ['./',

--- a/scopesim/tests/mocks/py_objects/yaml_objects.py
+++ b/scopesim/tests/mocks/py_objects/yaml_objects.py
@@ -8,7 +8,7 @@ FILES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../files/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 def _atmo_yaml_dict():
@@ -44,6 +44,7 @@ effects :
         pixel_scale: 0.004
         
 -   name : ignorable_effect
+    class : Effect
     include : False
 """
     return yaml.load(text)

--- a/scopesim/tests/mocks/yamls/SimpleCADO.yaml
+++ b/scopesim/tests/mocks/yamls/SimpleCADO.yaml
@@ -1,9 +1,14 @@
 ### DETECTOR
 object: detector
+alias: DET
 name: test_detector
+properties:
+  ndit: "!OBS.ndit"
+  dit: "!OBS.dit"
 
 effects:
-- name: SimpleCADO detector array list
+- name: test_detector_list
+  description: SimpleCADO detector array list
   class: DetectorList
   kwargs:
     array_dict: {"id": [1], "pixsize": [0.015], "angle": [0.], "gain": [1.0],
@@ -15,8 +20,38 @@ effects:
     pixsize_unit : mm
     angle_unit : deg
     gain_unit : electron/adu
+    image_plane_id: 0
 
-- name: SimpleCADO dark current
+- name: dark_current
+  description: SimpleCADO dark current
   class: DarkCurrent
   kwargs:
     value: 0.1    # [e-/s] level of dark currentSimpleCADO.yaml
+
+- name: alt_dark_current
+  description: SimpleCADO dark current
+  class: DarkCurrent
+  include: False
+  kwargs:
+    value: 0.5    # [e-/s] level of dark currentSimpleCADO.yaml
+
+---
+
+alias: OBS
+properties:
+  ndit: 1
+  dit: 10
+
+---
+
+alias: INST
+properties:
+  pixel_scale: 0.004
+  plate_scale: 0.2666667 # because optical train still need this (stupidly)
+
+---
+
+alias: TEL
+properties:
+  area: 1
+  area_unit: m2

--- a/scopesim/tests/tests_effects/test_ConstPSF.py
+++ b/scopesim/tests/tests_effects/test_ConstPSF.py
@@ -39,7 +39,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../mocks/yamls/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 @pytest.fixture(scope="function")

--- a/scopesim/tests/tests_effects/test_FVPSF.py
+++ b/scopesim/tests/tests_effects/test_FVPSF.py
@@ -40,7 +40,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../mocks/yamls/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 @pytest.fixture(scope="function")

--- a/scopesim/tests/tests_effects/test_LinearityCurve.py
+++ b/scopesim/tests/tests_effects/test_LinearityCurve.py
@@ -14,7 +14,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
 
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 class TestInit:

--- a/scopesim/tests/tests_effects/test_SkycalcTERCurve.py
+++ b/scopesim/tests/tests_effects/test_SkycalcTERCurve.py
@@ -7,6 +7,14 @@ from scopesim import rc
 TRAVIS = True if "TRAVIS" in os.environ else False
 
 
+def setup_module():
+    rc_local_path = rc.__config__["!SIM.file.local_packages_path"]
+    if not os.path.exists(rc_local_path):
+        os.mkdir(rc_local_path)
+        rc.__config__["!SIM.file.local_packages_path"] = os.path.abspath(
+            rc_local_path)
+
+
 def teardown_module():
     if os.path.exists("skycalc_temp.fits"):
         os.remove("skycalc_temp.fits")

--- a/scopesim/tests/tests_effects/test_SkycalcTERCurve.py
+++ b/scopesim/tests/tests_effects/test_SkycalcTERCurve.py
@@ -29,3 +29,8 @@ class TestInit:
             assert sky_ter.skycalc_conn.values["pwv"] == 20.0
             assert isinstance(sky_ter.surface.transmission, SpectralElement)
             assert isinstance(sky_ter.surface.emission, SourceSpectrum)
+
+    def test_initialises_with_non_skycalc_keys(self):
+        if TRAVIS:
+            sky_ter = SkycalcTERCurve(name="bogus")
+            assert "name" not in sky_ter.skycalc_conn.values

--- a/scopesim/tests/tests_integrations/test_flux_is_conserved_through_full_system.py
+++ b/scopesim/tests/tests_integrations/test_flux_is_conserved_through_full_system.py
@@ -23,7 +23,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../mocks/yamls/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 def _basic_cmds():

--- a/scopesim/tests/tests_integrations/test_hawki/test_full_package_hawki.py
+++ b/scopesim/tests/tests_integrations/test_hawki/test_full_package_hawki.py
@@ -18,7 +18,7 @@ from matplotlib.colors import LogNorm
 if rc.__config__["!SIM.tests.ignore_integration_tests"]:
     pytestmark = pytest.mark.skip("Ignoring HAWKI integration tests")
 
-rc.__config__["!SIM.file.local_packages_path"] = "./scopesim_pkg_dir_tmp/hawki_tmp/"
+rc.__config__["!SIM.file.local_packages_path"] = "./hawki_temp/"
 
 PKGS = {"Paranal": "locations/Paranal.zip",
         "VLT": "telescopes/VLT.zip",

--- a/scopesim/tests/tests_integrations/test_micado/test_full_package_micado.py
+++ b/scopesim/tests/tests_integrations/test_micado/test_full_package_micado.py
@@ -18,7 +18,7 @@ from matplotlib.colors import LogNorm
 if rc.__config__["!SIM.tests.ignore_integration_tests"]:
     pytestmark = pytest.mark.skip("Ignoring MICADO integration tests")
 
-rc.__config__["!SIM.file.local_packages_path"] = "./scopesim_pkg_dir_tmp/micado_tmp/"
+rc.__config__["!SIM.file.local_packages_path"] = "./micado_temp/"
 
 
 PKGS = {"Armazones": "locations/Armazones.zip",
@@ -26,7 +26,7 @@ PKGS = {"Armazones": "locations/Armazones.zip",
         "MAORY": "instruments/MAORY.zip",
         "MICADO": "instruments/MICADO.zip"}
 
-CLEAN_UP = True
+CLEAN_UP = False
 PLOTS = False
 
 

--- a/scopesim/tests/tests_integrations/test_simplecado.py
+++ b/scopesim/tests/tests_integrations/test_simplecado.py
@@ -42,10 +42,10 @@ DETECTOR_YAML = {"object": "detector",
                              {"name": "dark_current",
                               "description": "SimpleCADO dark current",
                               "class": "DarkCurrent",
-                              # [e-/s] level of dark currentSimpleCADO.yaml
+                              # [e-/s] level of dark current
                               "kwargs": {"value": 0.2,
                                          "dit": "!OBS.dit",
-                                         "ndit": "!OBS.ndit",}
+                                         "ndit": "!OBS.ndit"}
                               }]
                  }
 
@@ -53,7 +53,7 @@ OBSERVATIONS_DICT = {"!OBS.ndit": 1,                # Not yet implemented
                      "!OBS.dit" : 10,               # [sec]
                      "!INST.pixel_scale": 0.004,    # because optical train still need this (stupidly)
                      "!INST.plate_scale": 0.2666667 # because optical train still need this (stupidly)
-                    }
+                     }
 
 
 def test_simplecado():
@@ -75,6 +75,19 @@ def test_simplecado():
     # dark = 0.2 ct/s, DIT = 10s, NDIT = 1
     print(hdu[1].data)
     assert np.all(hdu[1].data == 2.0)
+
+
+def test_setitem_in_optical_train():
+    src = scopesim.source.source_templates.empty_sky()
+    cmd = sim.commands.UserCommands(yamls=[DETECTOR_YAML],
+                                    properties=OBSERVATIONS_DICT)
+
+    opt = sim.OpticalTrain(cmd)
+    opt["dark_current"].meta["include"] = False
+    assert opt["dark_current"].meta["include"] is False
+
+    opt["dark_current"].meta["include"] = True
+    assert opt["dark_current"].meta["include"] is True
 
 
 def read_in_simplecado_package():

--- a/scopesim/tests/tests_optics/test_FOVManager.py
+++ b/scopesim/tests/tests_optics/test_FOVManager.py
@@ -25,7 +25,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../mocks/yamls/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 @pytest.fixture(scope="function")

--- a/scopesim/tests/tests_optics/test_OpticalElement.py
+++ b/scopesim/tests/tests_optics/test_OpticalElement.py
@@ -37,24 +37,17 @@ class TestOpticalElementInit:
 
         assert opt_el.properties["temperature"] == 0
 
-    # Test is obsolete because Effects object should clean keywords, if needed,
-    #   not here in OpticalElement
-    # def test_cleans_obs_keywords_from_yaml_dict_effects(self, atmo_yaml_dict):
-    #     rc.__currsys__["!OBS.airmass"] = 1.5
-    #     atmo_yaml_dict["effects"][1]["kwargs"]["airmass"] = "!OBS.airmass"
-    #     opt_el = opt_elem.OpticalElement(atmo_yaml_dict)
-    #
-    #     assert opt_el.effects[1].meta["airmass"] == 1.5
-
-    def test_ignores_effects_with_keyword_include_false(self, atmo_yaml_dict):
+    def test_make_not_included_effects_but_set_flag_false(self, atmo_yaml_dict):
         opt_el = opt_elem.OpticalElement(atmo_yaml_dict)
-        assert len(opt_el.effects) == 2
+        assert len(opt_el.effects) == 3
+        assert opt_el.effects[2].include is False
 
-    def test_ignores_effects_in_currsys_ignore_effects(self, atmo_yaml_dict):
+    def test_currsys_ignore_effects_have_false_include_flag(self, atmo_yaml_dict):
         rc.__currsys__ = UserCommands()
         rc.__currsys__.ignore_effects = ["super_psf", "atmo_dispersion"]
         opt_el = opt_elem.OpticalElement(atmo_yaml_dict)
-        assert len(opt_el.effects) == 0
+        for ii in range(2):
+            assert opt_el.effects[ii].include is False
 
 
 @pytest.mark.usefixtures("detector_yaml_dict")

--- a/scopesim/tests/tests_optics/test_OpticsManager.py
+++ b/scopesim/tests/tests_optics/test_OpticsManager.py
@@ -17,7 +17,7 @@ YAMLS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                           "../mocks/MICADO_SCAO_WIDE/"))
 for NEW_PATH in [YAMLS_PATH, FILES_PATH]:
     if NEW_PATH not in rc.__search_path__:
-        rc.__search_path__ += [NEW_PATH]
+        rc.__search_path__.insert(0, NEW_PATH)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
As of commit 2930ec9 this is possible in the following manner:

List the effects modelled in an OpticalTrain::

    >>> print(opt.effects)

Effects can be accessed by using the name of the effect::

    >>> print(opt["dark_current"])

To include or exclude an effect during a simulation run, use the
``.include`` attribute of the effect::

     >>> opt["dark_current"].include = False

Data used by an Effect object is contained in the ``.data`` attribute, while
other information is contained in the ``.meta`` attribute::

    >>> opt["dark_current"].data
    >>> opt["dark_current"].meta

Meta data values can be set by either using the ``.meta`` attribute
directly::

    >>> opt["dark_current"].meta["value"] = 0.5

or by passing a dictionary (with one or multiple entries) to the
OpticalTrain object::

    >>> opt["dark_current"] = {"value": 0.75, "dit": 30}