### PR TITLE
Add astropy 4.0 support

### DIFF
--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -116,7 +116,7 @@ def photons_in_range(spectra, wave_min, wave_max, area=None, bandpass=None):
             counts += [np.trapz(y, x)]
 
     # counts = flux [ph s-1 cm-2]
-    counts = 1E4 * np.array(counts)    # to get from cm-2 to m-2
+    counts = 1E4 * np.array([c.value for c in counts])    # to get from cm-2 to m-2
     counts *= u.ph * u.s**-1 * u.m**-2
     if area is not None:
         counts *= utils.quantify(area, u.m ** 2)


### PR DESCRIPTION
Only change necessary for MICADO-WISE is converting counts to scalar values before converting them to floats in `source_utils.py`.

astropy 4.0 will otherwise raise "TypeError: only dimensionless scalar quantities can be converted to Python scalars"

The travis run shows that this is not yet enough. I'll do some proper ScopeSim tests first.

Note that master is now failing too: https://travis-ci.org/astronomyk/ScopeSim/builds/620198263
