### PR TITLE
Oc/01 psf convolution

### DIFF
--- a/scopesim/tests/tests_effects/test_ConstPSF.py
+++ b/scopesim/tests/tests_effects/test_ConstPSF.py
@@ -113,5 +113,22 @@ class TestApplyTo:
 
         assert np.max(fov_returned.hdu.data) == approx(max_pixel)
 
+    def test_convolution_leaves_constant_background_intact(self):
+        centre_fov = _centre_fov(n=10, waverange=[1.1, 1.3])
+        nax1, nax2 = centre_fov.header["NAXIS1"], centre_fov.header["NAXIS2"]
 
+        const_background = np.ones((nax2, nax1), dtype=np.float64)
+        centre_fov.hdu.data = np.zeros((nax2, nax1))
 
+        constpsf = FieldConstantPSF(filename="test_ConstPSF.fits")
+        fov_returned = constpsf.apply_to(centre_fov)
+
+        if PLOTS:
+            fig, (ax1, ax2) = plt.subplots(1, 2)
+            ax1.imshow(const_background)
+            ax1.set_title("before convolution")
+            ax2.imshow(fov_returned.hdu.data)
+            ax2.set_title("after convolution")
+            plt.show()
+
+            assert np.all(np.equal(fov_returned.hdu.data, const_background))


### PR DESCRIPTION
Might need a test?

PSF convolution on an image with significant background caused a gradient to appear in the simulated output. This was due to edge effects by the PSF reaching beyond the source field. I tried to avoid this by 
- subtracting the fov median before convolution
- re-adding the median after convolution
This should be sufficient for a constant background.

The background estimation and subtraction is controlled by a new parameter `bkg_width` with the following behaviour:
- `bkg_width < 0`:  median estimated over entire image
- `bkg_width = 0`: no background subtracted
- `bkg_width > 0`: background is estimated in a border region of that width

I have set the default to `-1`. 