### PR TITLE
Oc/04 slitwheel

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -353,7 +353,7 @@ class SlitWheel(Effect):
 
         super(SlitWheel, self).__init__(**kwargs)
 
-        params = {"z_order": [82, 282, 582],   # .todo check
+        params = {"z_order": [80, 280, 580],   # .todo check
                   "path": "",
                   "report_plot_include": True,
                   "report_table_include": True,

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -1,4 +1,5 @@
 '''Effects related to field masks, including spectroscopic slits'''
+from os import path as pth
 from copy import deepcopy
 import numpy as np
 from matplotlib.path import Path
@@ -372,6 +373,7 @@ class SlitWheel(Effect):
 
 
     def apply_to(self, obj):
+        '''Use apply_to of current_slit'''
         return self.current_slit.apply_to(obj)
 
 
@@ -380,14 +382,17 @@ class SlitWheel(Effect):
 
 
     @property
-    def current_filter(self):
+    def current_slit(self):
+        '''Return the currently used slit'''
         return self.slits[from_currsys(self.meta["current_slit"])]
 
     def __getattr__(self, item):
         return getattr(self.current_slit, item)
 
     ### def get_plot()
-    ### def get_table(self):
+    def get_table(self):
+        '''TODO make useful'''
+        return "something"
 
 ################################################################################
 

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -353,11 +353,11 @@ class SlitWheel(Effect):
 
         super(SlitWheel, self).__init__(**kwargs)
 
-        params = {"z_order": [80, 280, 580],   # .todo check
+        params = {"z_order": [80, 280, 580],
                   "path": "",
-                  "report_plot_include": True,
+                  "report_plot_include": False,
                   "report_table_include": True,
-                  "report_table_rounding": 4}  # .todo not sure what any of this means...
+                  "report_table_rounding": 4}
         self.meta.update(params)
         self.meta.update(kwargs)
 
@@ -380,6 +380,12 @@ class SlitWheel(Effect):
     def fov_grid(self, which="edges", **kwargs):
         return self.current_slit.fov_grid(which=which, **kwargs)
 
+    def change_slit(self, slitname=None):
+        '''Change the current slit'''
+        if slitname in self.slits.keys():
+            self.meta['current_slit'] = slitname
+        else:
+            raise ValueError("Unknown slit requested: " + slitname)
 
     @property
     def current_slit(self):

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -283,6 +283,7 @@ def get_spectroscopy_headers(effects, **kwargs):
     detector_list_effects = get_all_effects(effects, efs.DetectorList)
     spec_trace_effects = get_all_effects(effects, efs.SpectralTraceList)
     aperture_effects = get_all_effects(effects, (efs.ApertureList,
+                                                 efs.SlitWheel,
                                                  efs.ApertureMask))
 
     if len(surface_list_effects) > 0:

--- a/scopesim/optics/fov_manager_utils.py
+++ b/scopesim/optics/fov_manager_utils.py
@@ -162,6 +162,7 @@ def get_imaging_headers(effects, **kwargs):
 
     # look for apertures
     aperture_effects = get_all_effects(effects, (efs.ApertureMask,
+                                                 efs.SlitWheel,
                                                  efs.ApertureList))
     if len(aperture_effects) == 0:
         detector_arrays = get_all_effects(effects, efs.DetectorList)

--- a/scopesim/tests/mocks/files/MASK_slit_A.dat
+++ b/scopesim/tests/mocks/files/MASK_slit_A.dat
@@ -1,0 +1,16 @@
+# description : Slit mask for slit A 8000 x 19.0 mas
+# author : Oliver Czoske
+# source : Polarion METIS-1438
+# date_created : 2021-03-31
+# date_modified : 2021-03-31
+# status : system requirement approved 2020-10-13
+# type : aperture:slit_geometry
+# x_unit : mas
+# y_unit : mas
+# changes :
+#
+    x     y
+-4000  -9.5
+ 4000  -9.5
+ 4000   9.5
+-4000   9.5

--- a/scopesim/tests/mocks/files/MASK_slit_B.dat
+++ b/scopesim/tests/mocks/files/MASK_slit_B.dat
@@ -1,0 +1,16 @@
+# description : Slit mask for slit B 8000 x 28.6 mas
+# author : Oliver Czoske
+# source : Polarion METIS-1438
+# date_created : 2021-03-31
+# date_modified : 2021-03-31
+# status : system requirement approved 2020-10-13
+# type : aperture:slit_geometry
+# x_unit : mas
+# y_unit : mas
+# changes :
+#
+    x     y
+-4000  -14.3
+ 4000  -14.3
+ 4000   14.3
+-4000   14.3

--- a/scopesim/tests/tests_effects/test_slitwheel.py
+++ b/scopesim/tests/tests_effects/test_slitwheel.py
@@ -10,13 +10,15 @@ FILES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
 if FILES_PATH not in rc.__search_path__:
     rc.__search_path__ += [FILES_PATH]
 
-@pytest.fixture(scope="class")
-def swheel():
+@pytest.fixture(name="swheel", scope="class")
+def fixture_swheel():
     '''Instantiate a SlitWheel'''
     return SlitWheel(slit_names=["A", "B"],
                      filename_format="MASK_slit_{}.dat",
                      current_slit="B")
 
+# pylint: disable=no-self-use, missing-class-docstring,
+# pylint: disable=missing-function-docstring
 class TestSlitWheel:
     def test_initialises_correctly(self, swheel):
         assert isinstance(swheel, SlitWheel)
@@ -26,3 +28,6 @@ class TestSlitWheel:
 
     def test_current_slit_is_aperture_mask(self, swheel):
         assert isinstance(swheel.current_slit, ApertureMask)
+
+    def test_current_slit_has_fov_grid_method(self, swheel):
+        assert hasattr(swheel.current_slit, "fov_grid")

--- a/scopesim/tests/tests_effects/test_slitwheel.py
+++ b/scopesim/tests/tests_effects/test_slitwheel.py
@@ -31,3 +31,11 @@ class TestSlitWheel:
 
     def test_current_slit_has_fov_grid_method(self, swheel):
         assert hasattr(swheel.current_slit, "fov_grid")
+
+    def test_change_to_known_slit(self, swheel):
+        swheel.change_slit('A')
+        assert swheel.current_slit.meta['name'] == 'A'
+
+    def test_change_to_unknown_slit(self, swheel):
+        with pytest.raises(ValueError):
+            swheel.change_slit('X')

--- a/scopesim/tests/tests_effects/test_slitwheel.py
+++ b/scopesim/tests/tests_effects/test_slitwheel.py
@@ -1,0 +1,28 @@
+'''Tests for class SlitWheel'''
+import os
+import pytest
+
+from scopesim import rc
+from scopesim.effects import ApertureMask, SlitWheel
+
+FILES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                          "../mocks/files/"))
+if FILES_PATH not in rc.__search_path__:
+    rc.__search_path__ += [FILES_PATH]
+
+@pytest.fixture(scope="class")
+def swheel():
+    '''Instantiate a SlitWheel'''
+    return SlitWheel(slit_names=["A", "B"],
+                     filename_format="MASK_slit_{}.dat",
+                     current_slit="B")
+
+class TestSlitWheel:
+    def test_initialises_correctly(self, swheel):
+        assert isinstance(swheel, SlitWheel)
+
+    def test_has_aperture_masks(self, swheel):
+        assert len(swheel.table) == 2
+
+    def test_current_slit_is_aperture_mask(self, swheel):
+        assert isinstance(swheel.current_slit, ApertureMask)


### PR DESCRIPTION
SlitWheel should be ready for use, tests pass (some pylint messages have been disabled). 'open' position would be required for default use in imaging mode, this has not been implemented yet. SlitWheel can be already be used for imaging, but should have `include=False` by default.