### PR TITLE
add change_filter method; docstring change in apertures.py

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -329,7 +329,7 @@ class ApertureList(Effect):
 
 class SlitWheel(Effect):
     """
-    This wheel holds a selection of predefined spectroscopic filters
+    This wheel holds a selection of predefined spectroscopic slits
     and possibly other field masks.
 
     It should contain an open position.

--- a/scopesim/effects/ter_curves.py
+++ b/scopesim/effects/ter_curves.py
@@ -403,6 +403,7 @@ class SpanishVOFilterCurve(FilterCurve):
 
 class FilterWheel(Effect):
     """
+    This wheel holds a selection of predefined filters.
 
     Examples
     --------
@@ -431,7 +432,8 @@ class FilterWheel(Effect):
         self.meta.update(params)
         self.meta.update(kwargs)
 
-        path = pth.join(self.meta["path"], from_currsys(self.meta["filename_format"]))
+        path = pth.join(self.meta["path"],
+                        from_currsys(self.meta["filename_format"]))
         self.filters = {}
         for name in self.meta["filter_names"]:
             kwargs["name"] = name
@@ -441,10 +443,18 @@ class FilterWheel(Effect):
 
 
     def apply_to(self, obj):
+        '''Use apply_to of current filter'''
         return self.current_filter.apply_to(obj)
 
     def fov_grid(self, which="waveset", **kwargs):
         return self.current_filter.fov_grid(which=which, **kwargs)
+
+    def change_filter(self, filtername=None):
+        '''Change the current filter'''
+        if filtername in self.filters.keys():
+            self.meta['current_filter'] = filtername
+        else:
+            raise ValueError("Unknown filter requested: " + filtername)
 
     @property
     def current_filter(self):


### PR DESCRIPTION
I have added a `change_filter` method to `FilterWheel`, analogous to `change_slit`. Tests for `FilterWheel` have been rearranged and added to, all test in `TestFilterWheelInit` pass on my computer.