### PR TITLE
Oc/08 shutdown

### DIFF
--- a/scopesim/optics/optical_train.py
+++ b/scopesim/optics/optical_train.py
@@ -66,6 +66,7 @@ class OpticalTrain:
 
     def __init__(self, cmds=None):
 
+        self._description = self.__repr__()
         self.cmds = cmds
         self.optics_manager = None
         self.fov_manager = None
@@ -73,6 +74,7 @@ class OpticalTrain:
         self.detector_arrays = []
         self.yaml_dicts = None
         self._last_source = None
+
 
         if cmds is not None:
             self.load(cmds)
@@ -221,9 +223,28 @@ class OpticalTrain:
             self.cmds.update(packages=self.default_yamls[0]["packages"])
         rc.__currsys__ = self.cmds
 
+
+    def shutdown(self):
+        '''Shut down the instrument.
+
+        This method closes all open file handles and should be called when the optical train
+        is no longer needed.
+        '''
+        for effect_name in self.effects['name']:
+            try:
+                self[effect_name]._file.close()
+            except AttributeError:
+                pass
+
+        self._description = "The instrument has been shut down."
+
+
     @property
     def effects(self):
         return self.optics_manager.list_effects()
+
+    def __str__(self):
+        return self._description
 
     def __getitem__(self, item):
         return self.optics_manager[item]
@@ -247,5 +268,3 @@ class OpticalTrain:
         # etc
         #   limiting magnitudes
         #
-
-

--- a/scopesim/tests/tests_optics/test_OpticalTrain.py
+++ b/scopesim/tests/tests_optics/test_OpticalTrain.py
@@ -74,6 +74,11 @@ def simplecado_opt():
     cmd = sim.UserCommands(yamls=[simplecado_yaml])
     return sim.OpticalTrain(cmd)
 
+#@pytest.fixture(scope="class")
+#def micado_opt():
+#    micado_yaml = os.path.join(YAMLS_PATH, "test_scope.yaml")
+#    cmd = sim.UserCommands(yamls=[micado_yaml])
+#    return sim.OpticalTrain(cmd)
 
 @pytest.mark.usefixtures("cmds")
 class TestInit:
@@ -265,3 +270,18 @@ class TestListEffects:
         assert bool(simplecado_opt.effects["included"][2]) is True
 
         print("\n", simplecado_opt.effects)
+
+
+@pytest.mark.usefixtures("simplecado_opt")
+class TestShutdown:
+    # THIS TEST IS CURRENTLY USELESS AS SIMPLECADO HAS NO FITS FILE
+    def test_files_closed_on_shutdown(self, simplecado_opt):
+        simplecado_opt.shutdown()
+        flags = []
+        for effect_name in simplecado_opt.effects['name']:
+            try:
+                flags.append(simplecado_opt[effect_name]._file._file.closed)
+            except AttributeError:
+                pass
+
+        assert all(flags)


### PR DESCRIPTION
`OpticalTrain` gets a `shutdown()` method that closes all open FITS files. Tested in `test_OpticalTrain.py`. 

- Should `shutdown` do anything else?
- `test_files_closed_on_shutdown` uses two ways for testing that files are closed. Should these be split into two separate tests? 
- The method should be advertised in the manual and used in all notebooks. I'm not fond of editing notebooks - how do we deal with that?