### PR TITLE
Chop Nod combiner effect for science team operations

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -11,5 +11,6 @@ from . import ter_curves_utils
 
 from .detector_list import *
 from .electronic import *
+from .obs_strategies import *
 
 # from . import effects_utils

--- a/scopesim/effects/obs_strategies.py
+++ b/scopesim/effects/obs_strategies.py
@@ -10,23 +10,35 @@ class ChopNodCombiner(Effect):
     """
     Creates and combines 4 images for each of the chop/nod positions
 
-    - AA : original position (dx, dy) = (0, 0)
-    - AB : chop position (dx, dy) = chop_offsets
-    - BA : nod position (dx, dy) = nod_offsets
-    - BA : chop-nod position (dx, dy) = nod_offsets + chop_offsets
+    - AA : original position ``(dx, dy) = (0, 0)``
+    - AB : chop position ``(dx, dy) = chop_offsets``
+    - BA : nod position ``(dx, dy) = nod_offsets``
+    - BA : chop-nod position ``(dx, dy) = nod_offsets + chop_offsets``
 
     Images are combined using::
 
         im_combined = (AA - AB) - (BA - BB)
 
-    If no
+    If no ``nod_offset`` is given, it is set to the inverse of ``chop_offset``.
 
-    kwargs
-    ------
+    Keyword arguments
+    -----------------
     chop_offsets : tuple, optinal
         [arcsec] (dx, dy) offset of chop poisition relative to AA
     nod_offsets : tuple, optinal
         [arcsec] (dx, dy) offset of nod poisition relative to AA
+
+    Example yaml entry
+    ------------------
+    ::
+        name: perpendicular_chop_nod_slanted_pattern
+        description: chop throw to (+5, 0) and nod throw to (-7, +10) arcsec
+        class: ChopNodCombiner
+        include: True
+        kwargs:
+            pixel_scale : "!INST.pixel_scale"
+            chop_offsets : (5, 0)
+            nod_offsets : (-7, 10)
 
     """
 

--- a/scopesim/effects/obs_strategies.py
+++ b/scopesim/effects/obs_strategies.py
@@ -1,0 +1,76 @@
+import numpy as np
+from matplotlib import pyplot as plt
+
+from scopesim.base_classes import ImagePlaneBase
+from scopesim.effects import Effect
+from scopesim.utils import from_currsys, check_keys
+
+
+class ChopNodCombiner(Effect):
+    """
+    Creates and combines 4 images for each of the chop/nod positions
+
+    - AA : original position (dx, dy) = (0, 0)
+    - AB : chop position (dx, dy) = chop_offsets
+    - BA : nod position (dx, dy) = nod_offsets
+    - BA : chop-nod position (dx, dy) = nod_offsets + chop_offsets
+
+    Images are combined using::
+
+        im_combined = (AA - AB) - (BA - BB)
+
+    If no
+
+    kwargs
+    ------
+    chop_offsets : tuple, optinal
+        [arcsec] (dx, dy) offset of chop poisition relative to AA
+    nod_offsets : tuple, optinal
+        [arcsec] (dx, dy) offset of nod poisition relative to AA
+
+    """
+
+    def __init__(self, **kwargs):
+        check_keys(kwargs, ["chop_offsets", "pixel_scale"])
+
+        super(Effect, self).__init__(**kwargs)
+        params = {"chop_offsets": None,
+                  "nod_offsets": None,
+                  "pixel_scale": None,
+                  "include": True,
+                  "z_order": []}
+        self.meta.update(params)
+        self.meta.update(kwargs)
+
+    def apply_to(self, obj):
+        if isinstance(obj, ImagePlaneBase):
+            chop_offsets = from_currsys(self.meta["chop_offsets"])
+            nod_offsets = from_currsys(self.meta["nod_offsets"])
+            if nod_offsets is None:
+                nod_offsets = -np.array(chop_offsets)
+
+            # these offsets are in pixels, not in arcsec or mm
+            pixel_scale = float(from_currsys(self.meta["pixel_scale"]))
+            chop_offsets_pixel = np.array(chop_offsets) / pixel_scale
+            nod_offsets_pixel = np.array(nod_offsets) / pixel_scale
+
+            image = obj.hdu.data
+            obj.hdu.data = chop_nod_image(image,
+                                          chop_offsets_pixel.astype(int),
+                                          nod_offsets_pixel.astype(int))
+
+        return obj
+
+
+def chop_nod_image(im, chop_offsets, nod_offsets=None):
+    if nod_offsets is None:
+        nod_offsets = tuple(-np.array(chop_offsets))
+
+    im_AA = np.copy(im)
+    im_AB = np.roll(im_AA, chop_offsets, (1, 0))
+    im_BA = np.roll(im_AA, nod_offsets, (1, 0))
+    im_BB = np.roll(im_BA, chop_offsets, (1, 0))
+
+    im_comb = (im_AA - im_AB) - (im_BA - im_BB)
+
+    return im_comb

--- a/scopesim/source/source.py
+++ b/scopesim/source/source.py
@@ -126,7 +126,7 @@ class Source(SourceBase):
 
     See Also
     --------
-    synphot - https://synphot.readthedocs.io/en/latest/
+    synphot : ``https://synphot.readthedocs.io/en/latest/``
 
     """
 

--- a/scopesim/tests/tests_effects/test_obs_strategies.py
+++ b/scopesim/tests/tests_effects/test_obs_strategies.py
@@ -1,0 +1,58 @@
+import pytest
+from pytest import approx
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+
+from scopesim.effects.obs_strategies import ChopNodCombiner
+from scopesim.optics import ImagePlane
+from scopesim.tests.mocks.py_objects.header_objects import _implane_header
+
+
+PLOTS = False
+
+@pytest.fixture(scope="function")
+def basic_image_plane():
+    # An image plane image with background=100 and object_flux=1
+    imp = ImagePlane(_implane_header())
+    n = imp.header["NAXIS1"]
+    im = np.ones((n, n)) * 100              # background level = 100
+    im[n//2-5:n//2+5, n//2-5:n//2+5] += 1   # object flux level += 1
+    imp.hdu.data = im
+
+    return imp
+
+
+class TestChopNodCombinerInit:
+    def test_initilises_with_required_keywords(self):
+        cnc = ChopNodCombiner(pixel_scale=0.004, chop_offsets=(0.12, 0))
+        assert isinstance(cnc, ChopNodCombiner)
+
+    def test_throws_error_when_missing_keywords(self):
+        with pytest.raises(ValueError):
+            ChopNodCombiner()
+
+
+@pytest.mark.usefixtures("basic_image_plane")
+class TestChopNodCombinerApplyTo:
+    def test_creates_image_for_parallel_chop(self, basic_image_plane):
+        cnc = ChopNodCombiner(pixel_scale=0.004, chop_offsets=(0.12, 0))
+        basic_image_plane = cnc.apply_to(basic_image_plane)
+
+        if PLOTS:
+            plt.imshow(basic_image_plane.hdu.data)
+            plt.show()
+
+        assert np.sum(basic_image_plane.hdu.data) == 0
+
+    def test_creates_image_for_perpendicular_chop(self, basic_image_plane):
+        cnc = ChopNodCombiner(pixel_scale=0.004, chop_offsets=(0.12, 0),
+                              nod_offsets=(0, -0.20))
+        basic_image_plane = cnc.apply_to(basic_image_plane)
+
+        if PLOTS:
+            plt.imshow(basic_image_plane.hdu.data)
+            plt.show()
+
+        assert np.sum(basic_image_plane.hdu.data) == 0


### PR DESCRIPTION
 Creates and combines 4 images for each of the chop/nod positions

- AA : original position ``(dx, dy) = (0, 0)``
- AB : chop position ``(dx, dy) = chop_offsets``
- BA : nod position ``(dx, dy) = nod_offsets``
- BB : chop-nod position ``(dx, dy) = nod_offsets + chop_offsets``

Images are combined using::

    im_combined = (AA - AB) - (BA - BB)

If no ``nod_offset`` is given, it is set to the inverse of ``chop_offset``.
